### PR TITLE
[fix] #35 로그인 시 쿠키 저장 오류

### DIFF
--- a/src/app/api/login.ts
+++ b/src/app/api/login.ts
@@ -23,15 +23,11 @@ export const postLogin = async (values: LoginProps, ctx?: GetServerSidePropsCont
     setCookie(ctx, 'accessToken', accessToken, {
       maxAge: 30 * 24 * 60 * 60, 
       path: '/',
-      httpOnly: true,
-      secure: true
     });
 
     setCookie(ctx, 'refreshToken', refreshToken, {
       maxAge: 30 * 24 * 60 * 60, 
       path: '/',
-      httpOnly: true,
-      secure: true
     });
 
     return true;

--- a/src/app/hooks/login/useSocialLogin.ts
+++ b/src/app/hooks/login/useSocialLogin.ts
@@ -36,15 +36,11 @@ interface UseSocialLoginProps {
           setCookie(null, 'accessToken', accessToken, {
             maxAge: 30 * 24 * 60 * 60, 
             path: '/',
-            httpOnly: true,
-            secure: true
           });
       
           setCookie(null, 'refreshToken', refreshToken, {
             maxAge: 30 * 24 * 60 * 60, 
             path: '/',
-            httpOnly: true,
-            secure: true
           });
 
           switch (user.status) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
로그인 시 발급되는 토큰이 쿠키에 저장되지 않아 로그인이 튕기는 문제 해결하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
없습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
- [x] 로그인 시 발급되는 쿠키 저장 로직에 httpOnly 및 secure 설정 제거 
<br>

## 5. 추가 사항
배포 후 테스트 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **보안 변경**
	- 로그인 및 소셜 로그인 쿠키 설정에서 `httpOnly`와 `secure` 옵션을 제거했습니다.
	- 쿠키 보안 설정이 변경되어 클라이언트 측 JavaScript에서 토큰 접근이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->