### PR TITLE
[fix] #37 getPresignedUrl response 객체 명 오탈자 수정

### DIFF
--- a/src/app/hooks/useImageUpload.ts
+++ b/src/app/hooks/useImageUpload.ts
@@ -14,7 +14,7 @@ export const useImageUpload = (prefix: string, maxImages: number = 3) => {
       });
 
       return {
-        presignedUrl: data.presignedUrl,
+        presignedUrl: data.preSignedUrl,
         objectUrl: data.objectUrl,
       };
     } catch (error) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 기존에 getPresignedUrl 함수에서 presignedUrl을 반환 받기위한 api 요청을 했을 때 작성했던 response값에 오탈자가 있었습니다.
```javascript
return {
        presignedUrl: data.preSignedUrl, // presignedUrl -> preSignedUrl로 수정하였습니다.
        objectUrl: data.objectUrl,
      };
```
<br>
