### PR TITLE
[refactor] #38 presignedUrl을 사용하여 프로필 업데이트 및 판매점 등록 api 수정

### DIFF
--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -8,7 +8,7 @@ import { logout } from '@/app/api/login';
 
 interface UserProfileState {
   nickname: string;
-  profileImage: { url: string | null };
+  profileImage: string;
   rank: number | null;
   storeReportCount: number;
 }
@@ -16,7 +16,7 @@ interface UserProfileState {
 export default function Mypage() {
   const [userProfile, setUserProfile] = useState<UserProfileState>({
     nickname: '',
-    profileImage: { url: null },
+    profileImage: '',
     rank: null,
     storeReportCount: 0,
   });
@@ -27,7 +27,7 @@ export default function Mypage() {
       if (profile) {
         setUserProfile({
           ...profile,
-          profileImage: profile.profileImage || { url: null },
+          profileImage: profile.profileImage || '',
         });
       }
     };
@@ -47,13 +47,14 @@ export default function Mypage() {
         storeReportCount={userProfile.storeReportCount}
       />
 
+      <button
+        className="bg-main w-11/12 mb-24 font-semibold text-white text-sm mx-5 py-4 rounded-2xl"
+        onClick={() => logout()}
+      >
+        로그아웃
+      </button>
+
       <div className="mt-auto">
-        <button
-          className="bg-main w-11/12 mb-24 font-semibold text-white text-sm mx-5 py-4 rounded-2xl"
-          onClick={() => logout()}
-        >
-          로그아웃
-        </button>
         <Navbar />
       </div>
     </div>

--- a/src/app/(route)/mypage/profile/page.tsx
+++ b/src/app/(route)/mypage/profile/page.tsx
@@ -28,7 +28,12 @@ export default function Profile() {
 
   const addImageFromUrl = (url: string) => {
     if (url) {
-      addImage(new File([], url));
+      try {
+        addImage(new File([], url));
+      } catch (error) {
+        console.error('이미지 URL 처리 중 오류:', error);
+        alert('이미지를 불러오는데 실패했습니다.');
+      }
     }
   };
 

--- a/src/app/(route)/mypage/profile/page.tsx
+++ b/src/app/(route)/mypage/profile/page.tsx
@@ -1,58 +1,55 @@
-"use client";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { useState, useRef, useEffect } from "react";
-import BackButton from "@/app/_components/common/BackButton";
-import { UserIcon } from "@/app/assets";
-import { Navbar } from "@/app/_components/Navbar";
-import { updateProfile, getUserProfile } from "@/app/api/mypage";
+'use client';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { useState, useRef, useEffect } from 'react';
+import BackButton from '@/app/_components/common/BackButton';
+import { UserIcon } from '@/app/assets';
+import { Navbar } from '@/app/_components/Navbar';
+import { updateProfile, getUserProfile } from '@/app/api/mypage';
+import { useImageUpload } from '@/app/hooks/useImageUpload';
 
 export default function Profile() {
   const router = useRouter();
-  const [nickname, setNickname] = useState("");
-  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const [nickname, setNickname] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { images, addImage, isUploading } = useImageUpload('user', 1);
 
   useEffect(() => {
     const fetchProfile = async () => {
       const userProfile = await getUserProfile();
       if (userProfile) {
         setNickname(userProfile.nickname);
-        setProfileImageUrl(userProfile.profileImage.url);
+        addImageFromUrl(userProfile.profileImage);
       }
     };
 
     fetchProfile();
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      let imageFile: File | null | undefined = null;
-      if (fileInputRef.current?.files?.length) {
-        imageFile = fileInputRef.current.files[0];
-      }
-
-      const response = await updateProfile(nickname, imageFile);
-
-      if (response) {
-        alert("프로필이 성공적으로 업데이트되었습니다.");
-        router.push("/mypage");
-      }
-    } catch (error) {
-      console.error("프로필 업데이트 실패:", error);
-      alert("프로필 업데이트에 실패했습니다. 다시 시도해주세요.");
+  const addImageFromUrl = (url: string) => {
+    if (url) {
+      addImage(new File([], url));
     }
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const response = await updateProfile(nickname, images[0] || null);
+      if (response) {
+        alert('프로필이 성공적으로 업데이트되었습니다.');
+        router.push('/mypage');
+      }
+    } catch (error) {
+      console.error('프로필 업데이트 실패:', error);
+      alert('프로필 업데이트에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        setProfileImageUrl(e.target?.result as string);
-      };
-      reader.readAsDataURL(file);
+      await addImage(file);
     }
   };
 
@@ -64,15 +61,16 @@ export default function Profile() {
         <button
           className="text-sm mt-9 mr-9 font-medium"
           onClick={handleSubmit}
+          disabled={isUploading}
         >
           완료
         </button>
       </div>
 
       <div className="flex flex-col justify-center items-center mt-12 space-y-3">
-        {profileImageUrl ? (
+        {images[0] ? (
           <Image
-            src={profileImageUrl}
+            src={images[0]}
             alt="프로필 이미지"
             width={70}
             height={70}
@@ -84,8 +82,9 @@ export default function Profile() {
         <button
           className="text-xs font-semibold text-main"
           onClick={() => fileInputRef.current?.click()}
+          disabled={isUploading}
         >
-          사진 수정
+          {isUploading ? '업로드 중...' : '사진 수정'}
         </button>
         <input
           type="file"

--- a/src/app/_components/mypage/UserProfile.tsx
+++ b/src/app/_components/mypage/UserProfile.tsx
@@ -4,14 +4,14 @@ import { UserIcon } from '@/app/assets';
 
 interface ProfileProps {
   nickname: string;
-  profileImageUrl: { url: string | null };
+  profileImageUrl: string;
 }
 
 export const UserProfile: React.FC<ProfileProps> = ({
   nickname,
   profileImageUrl,
 }) => {
-  const imageUrl = profileImageUrl.url;
+  const imageUrl = profileImageUrl;
   const router = useRouter();
 
   const handleProfileEdit = () => {

--- a/src/app/_components/report/ImageUploader.tsx
+++ b/src/app/_components/report/ImageUploader.tsx
@@ -10,18 +10,20 @@ export const ImageUploader = () => {
   return (
     <div className="bg-white flex flex-col space-y-3 rounded-xl p-4 pb-6 mt-4">
       <div className="font-semibold text-sm text-left">가게 사진</div>
-      <ImageUploadButton
-        imageCount={images.length}
-        isFull={isFull}
-        onUpload={addImage}
-      />
-      {isUploading ? (
-        <div className="text-center text-xs text-gray-300">업로드 중...</div>
-      ) : (
-        images.map((image, index) => (
-          <ImagePreview key={index} imgUrl={image} />
-        ))
-      )}
+      <div className="flex flex-row space-x-2">
+        <ImageUploadButton
+          imageCount={images.length}
+          isFull={isFull}
+          onUpload={addImage}
+        />
+        {isUploading ? (
+          <div className="text-center text-xs text-gray-300">업로드 중...</div>
+        ) : (
+          images.map((image, index) => (
+            <ImagePreview key={index} imgUrl={image} />
+          ))
+        )}
+      </div>
     </div>
   );
 };

--- a/src/app/_components/report/ReportButton.tsx
+++ b/src/app/_components/report/ReportButton.tsx
@@ -3,23 +3,22 @@ import React from 'react';
 import { registerStore } from '@/app/api/report';
 import { useSelectStore, useSearchStore } from '@/app/zustand/reportStore';
 import { useLandingStore } from '@/app/zustand/landingStore';
-
 import { useRouter } from 'next/navigation';
 
 export const ReportButton: React.FC = () => {
-  const { placeName, longitude, latitude, imageFiles, resetSelectStore } =
+  const { placeName, longitude, latitude, images, resetSelectStore } =
     useSelectStore();
   const { resetSearchStore } = useSearchStore();
   const { resetLanding } = useLandingStore();
-
   const router = useRouter();
+
   const handleReport = async () => {
     try {
       const response = await registerStore(
         placeName,
         longitude,
         latitude,
-        imageFiles,
+        images,
       );
       if (response) {
         alert('판매점이 등록되었습니다!');

--- a/src/app/api/mypage.ts
+++ b/src/app/api/mypage.ts
@@ -4,11 +4,9 @@ interface UserProfileResponse {
     success: boolean;
     userProfile: {
         nickname: string;
-        profileImage: {
-            url: string | null;
-        };
-        rank: number | null; // 없을 시 null
-        storeReportCount: number; // 기본값 0
+        profileImage: string;
+        rank: number | null; 
+        storeReportCount: number; 
     };
 }
 
@@ -29,25 +27,14 @@ export const getUserProfile = async (): Promise<UserProfileResponse['userProfile
 }
 
   
-export const updateProfile = async (nickname: string, imageFile: File | null | undefined) => {
+export const updateProfile = async (nickname: string, imageUrl: string | null) => {
   try {
-    const formData = new FormData();
-    if (imageFile) {
-      formData.append('imageFile', imageFile);
-    } else {
-      formData.append('imageFile', '');
-    }
-
-    const config = {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-      params: {
-        nickname: nickname
-      }
+    const payload = {
+      nickname,
+      image: imageUrl || "", 
     };
 
-    const response = await axiosInstance.patch('/user', formData, config);
+    const response = await axiosInstance.patch('/user', payload);
     return response.data;
   } catch (error) {
     console.error('프로필 업데이트 중 오류 발생:', error);

--- a/src/app/api/report.ts
+++ b/src/app/api/report.ts
@@ -21,21 +21,19 @@ export const searchStore = async (query: string) => {
     }
 }
 
-export const registerStore = async (placeName: string, longitude: string, latitude: string, imageFiles: File[]) => {
+export const registerStore = async (placeName: string, longitude: string, latitude: string, images: string[]) => {
     try {
-        const formData = new FormData();
-        formData.append('placeName', placeName);
-        formData.append('longitude', longitude);
-        formData.append('latitude', latitude);
+        const payload = {
+            placeName,
+            longitude,
+            latitude,
+            images, 
+        };
 
-        imageFiles.forEach((file) => {
-            formData.append('imageFiles', file);
-        });
-
-        const { data } = await axiosInstance.post('/store', formData, {
+        const { data } = await axiosInstance.post('/store', payload, {
             headers: {
-                'Content-Type': 'multipart/form-data',
-                'accept': '*/*',
+                'Content-Type': 'application/json',
+                accept: '*/*',
             },
         });
 

--- a/src/app/zustand/detailStore.ts
+++ b/src/app/zustand/detailStore.ts
@@ -35,12 +35,12 @@ interface ZeroDrink {
 interface SelectedStoreState {
   storeId: string;
   filter: 'RECENT' | 'RECOMMEND'; 
-  images: Image[];
+  images: string[];
   reviews: ReviewData[];
   zeroDrinks: ZeroDrink[][];
   setStoreId: (storeId: string) => void;
   setFilter: (filter: 'RECENT' | 'RECOMMEND') => void; 
-  setImages: (images: Image[]) => void;
+  setImages: (images: string[]) => void;
   setReviews: (reviews: ReviewData[]) => void;
   setZeroDrinks: (zeroDrinks: ZeroDrink[][]) => void;
   resetSelectedStore: () => void; 

--- a/src/app/zustand/reportStore.ts
+++ b/src/app/zustand/reportStore.ts
@@ -11,27 +11,6 @@ interface SearchStoreState {
   resetSearchStore: () => void;  
 }
 
-interface SelectStoreState {
-  id: string;
-  placeName: string;
-  phone: string;
-  address: string;
-  category: string;
-  longitude: string;
-  latitude: string;
-  status: boolean;
-  imageFiles: File[];
-  setId: (id: string) => void;
-  setPlaceName: (placeName: string) => void;
-  setPhone: (phone: string) => void;
-  setCategory: (category: string) => void;
-  setAddress: (address: string) => void;
-  setLongitude: (longitude: string) => void;
-  setLatitude: (latitude: string) => void;
-  setImageFiles: (imageFiles: File[]) => void;
-  setStatus: (status: boolean) => void;
-  resetSelectStore: () => void;
-}
 
 export const useSearchStore = create<SearchStoreState>((set) => ({
   searchResults: [],
@@ -46,6 +25,27 @@ const getFromLocalStorage = (key: string, defaultValue: any) => {
   const value = localStorage.getItem(key);
   return value ? JSON.parse(value) : defaultValue;
 };
+interface SelectStoreState {
+  id: string;
+  placeName: string;
+  phone: string;
+  address: string;
+  category: string;
+  longitude: string;
+  latitude: string;
+  status: boolean;
+  images: string[]; 
+  setId: (id: string) => void;
+  setPlaceName: (placeName: string) => void;
+  setPhone: (phone: string) => void;
+  setCategory: (category: string) => void;
+  setAddress: (address: string) => void;
+  setLongitude: (longitude: string) => void;
+  setLatitude: (latitude: string) => void;
+  setImages: (images: string[]) => void; 
+  setStatus: (status: boolean) => void;
+  resetSelectStore: () => void;
+}
 
 export const useSelectStore = create<SelectStoreState>((set) => ({
   id: getFromLocalStorage('id', ''),
@@ -56,7 +56,7 @@ export const useSelectStore = create<SelectStoreState>((set) => ({
   longitude: getFromLocalStorage('longitude', ''),
   latitude: getFromLocalStorage('latitude', ''),
   status: getFromLocalStorage('status', false),
-  imageFiles: getFromLocalStorage('imageFiles', []),
+  images: getFromLocalStorage('images', []), 
   setId: (id) => {
     set({ id });
     if (typeof window !== 'undefined') {
@@ -105,10 +105,10 @@ export const useSelectStore = create<SelectStoreState>((set) => ({
       localStorage.setItem('status', JSON.stringify(status));
     }
   },
-  setImageFiles: (imageFiles) => {
-    set({ imageFiles });
+  setImages: (images) => { 
+    set({ images });
     if (typeof window !== 'undefined') {
-      localStorage.setItem('imageFiles', JSON.stringify(imageFiles.map(file => file.name)));
+      localStorage.setItem('images', JSON.stringify(images));
     }
   },
   resetSelectStore: () => {
@@ -121,7 +121,7 @@ export const useSelectStore = create<SelectStoreState>((set) => ({
       longitude: '',
       latitude: '',
       status: false,
-      imageFiles: [],
+      images: [],
     });
     if (typeof window !== 'undefined') {
       localStorage.removeItem('id');
@@ -132,7 +132,7 @@ export const useSelectStore = create<SelectStoreState>((set) => ({
       localStorage.removeItem('longitude');
       localStorage.removeItem('latitude');
       localStorage.removeItem('status');
-      localStorage.removeItem('imageFiles');
+      localStorage.removeItem('images');
     }
   },
 }));


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
presignedUrl을 사용하여 프로필 업데이트 및 판매점 등록 api request 값을 `string`으로 수정합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
배포 후 오류를 확인해봐야 할 것 같습니다.
<br>

## 3.  완료 사항

- [x] 아래 두가지 api 호출 함수에 포함된 이미지 값을 `File` 에서 `string`으로 수정
  - `updateProfile` : 프로필 업데이트 api
  - `registerStore` : 판매점 등록 api 
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 프로필 관리 경험이 개선되어 이미지 업로드가 간편해졌으며, 업로드 진행 상태를 확인할 수 있습니다.
  - MyPage에 새로운 로그아웃 버튼이 추가되어 계정 관리가 더욱 직관적입니다.
  - 검색 결과 및 쿼리 문자열을 관리하는 새로운 Zustand 스토어가 추가되었습니다.

- **Style**
  - 이미지 업로드 영역의 레이아웃이 재정비되어, 전체 인터페이스가 보다 깔끔하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->