### PR TITLE
[fix] #39 판매점 등록 api 요청 시 images 배열이 빈 배열로 들어가는 오류

### DIFF
--- a/src/app/_components/report/ImageUploader.tsx
+++ b/src/app/_components/report/ImageUploader.tsx
@@ -1,11 +1,17 @@
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useImageUpload } from '@/app/hooks/useImageUpload';
 import { ImagePreview } from '@/app/_components/report/ImagePreview';
 import { ImageUploadButton } from '@/app/_components/report/ImageUploadButton';
+import { useSelectStore } from '@/app/zustand/reportStore';
 
 export const ImageUploader = () => {
   const { images, addImage, isFull, isUploading } = useImageUpload('store', 3);
+  const { setImages } = useSelectStore();
+
+  useEffect(() => {
+    setImages(images);
+  }, [images, setImages]);
 
   return (
     <div className="bg-white flex flex-col space-y-3 rounded-xl p-4 pb-6 mt-4">


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
판매점 등록 api 요청 시 images 배열이 빈 배열로 들어가는 오류가 발생하였습니다.
<br>

## 2. 완료 사항

- [x] ImageUploader 컴포넌트에서 이미지 url에 대한 값을 useSelectStore에 포함된 Image 전역 상태에 업데이트 해주도록 수정
close #77 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 이미지 업로더 기능이 개선되어 사용자가 선택한 이미지가 애플리케이션의 전체 상태와 원활하게 동기화됩니다. 이로 인해 이미지 관리의 일관성이 향상되어 보다 안정적인 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->