### PR TITLE
[feat] #40 상세페이지 이미지 클릭 시 확대 모달 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@svgr/webpack": "^8.1.0",
         "axios": "^1.7.2",
         "framer-motion": "^11.2.13",
+        "lucide-react": "^0.475.0",
         "next": "14.2.4",
         "nookies": "^2.5.2",
         "react": "^18",
@@ -5623,6 +5624,14 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.475.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.475.0.tgz",
+      "integrity": "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/mdn-data": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@svgr/webpack": "^8.1.0",
     "axios": "^1.7.2",
     "framer-motion": "^11.2.13",
+    "lucide-react": "^0.475.0",
     "next": "14.2.4",
     "nookies": "^2.5.2",
     "react": "^18",

--- a/src/app/(route)/store/[id]/page.tsx
+++ b/src/app/(route)/store/[id]/page.tsx
@@ -1,13 +1,17 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 import React, { useEffect, useState } from 'react';
 import { DetailHeader } from '@/app/_components/store/DetailHeader';
 import { StoreInfo } from '@/app/_components/store/StoreInfo';
-import { RegisteredStoreImage } from '@/app/_components/store/RegisteredStoreImage';
 import { StoreReview } from '@/app/_components/store/StoreReview';
 import { useSelectedStore } from '@/app/zustand/detailStore';
 import { getStoreInfo } from '@/app/api/detail';
 import { useParams } from 'next/navigation';
 import Loading from '@/app/loading';
+
+import Image from 'next/image';
+import RegisteredStoreImage from '@/app/_components/store/RegisteredStoreImage';
+import Modal from '@/app/_components/common/Modal';
 
 export interface Store {
   id: string;
@@ -34,6 +38,8 @@ export default function RegisteredStore() {
   const [isLoading, setIsLoading] = useState(true);
   const [storeInfo, setStoreInfo] = useState<Store>();
   const [storeId, setStoreId] = useState<string>('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
   const fetchStoreInfo = async (value: string) => {
     try {
@@ -41,10 +47,6 @@ export default function RegisteredStore() {
       console.log(storeInfo.store);
       if (storeInfo) {
         setStoreInfo(storeInfo.store);
-        // setStoreId(storeInfo.store.id || '');
-        // setImages(storeInfo.store.images || []);
-        // setReviews(storeInfo.reviews || []);
-        // setZeroDrinks(storeInfo.zeroDrinks || [[]]);
       }
     } catch (error) {
       console.error('판매점 조회 오류', error);
@@ -53,12 +55,22 @@ export default function RegisteredStore() {
     }
   };
 
+  const openImageModal = (imageUrl: string) => {
+    setSelectedImage(imageUrl);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedImage(null);
+  };
+
   useEffect(() => {
     if (params?.id) {
       fetchStoreInfo(params.id);
       setStoreId(params.id);
     }
-  }, []);
+  }, [params?.id]);
 
   if (isLoading) {
     return <Loading />;
@@ -74,9 +86,26 @@ export default function RegisteredStore() {
         category={storeInfo?.category}
       />
       <div className="flex flex-col space-y-3 mt-3">
-        <RegisteredStoreImage images={storeInfo?.images} />
+        <RegisteredStoreImage
+          images={storeInfo?.images}
+          onImageClick={openImageModal}
+        />
         <StoreReview storeId={storeId} />
       </div>
+
+      <Modal isOpen={isModalOpen} onClose={closeModal}>
+        {selectedImage && (
+          <div className="relative">
+            <Image
+              src={selectedImage}
+              alt={`store-image`}
+              width={800}
+              height={600}
+              className="object-cover"
+            />
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/src/app/_components/common/Modal.tsx
+++ b/src/app/_components/common/Modal.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+      <div className="absolute left-7 top-9 z-10 flex cursor-pointer items-center">
+        <X onClick={onClose} className="text-white" />
+      </div>
+      <div className="relative">{children}</div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/app/_components/store/RegisteredStoreImage.tsx
+++ b/src/app/_components/store/RegisteredStoreImage.tsx
@@ -2,12 +2,14 @@
 import Image from 'next/image';
 
 interface RegisteredStoreImageProps {
-  images?: {
-    url: string;
-  }[];
+  images?: { url: string }[];
+  onImageClick: (imageUrl: string) => void;
 }
 
-export const RegisteredStoreImage = ({ images }: RegisteredStoreImageProps) => {
+const RegisteredStoreImage = ({
+  images,
+  onImageClick,
+}: RegisteredStoreImageProps) => {
   return (
     <div className="w-10/12 bg-white py-4 px-5 rounded-2xl space-y-4 ml-10">
       <div className="font-semibold text-sm text-left">가게 사진</div>
@@ -16,7 +18,8 @@ export const RegisteredStoreImage = ({ images }: RegisteredStoreImageProps) => {
           images.map((image, i) => (
             <div
               key={i}
-              className="w-20 h-20 bg-gray-200 rounded-xl flex items-center justify-center overflow-hidden"
+              className="w-20 h-20 bg-gray-200 rounded-xl flex items-center justify-center overflow-hidden cursor-pointer"
+              onClick={() => onImageClick(image.url)}
             >
               <Image
                 src={image.url}
@@ -34,3 +37,5 @@ export const RegisteredStoreImage = ({ images }: RegisteredStoreImageProps) => {
     </div>
   );
 };
+
+export default RegisteredStoreImage;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
상세페이지 이미지 클릭 시 확대 모달 로직 구현합니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
없습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="300px" src="https://github.com/user-attachments/assets/07491d69-ed5d-41c7-81bb-b0b7d65abc10">

<br>

## 4. 완료 사항
- [x] Modal 컴포넌트 구현
- [x] 이미지 확대 모달 로직 구현
close #79 
<br>

## 5. 추가 사항
없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 스토어 페이지에서 이미지를 클릭하면 모달 창이 열려 이미지의 상세보기 기능이 추가되었습니다.
	- 모달 창에는 직관적인 닫기 버튼이 포함되어 사용자 경험이 개선되었습니다.
  
- **잡무**
	- UI 아이콘 지원 강화를 위해 새로운 외부 라이브러리가 프로젝트에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->