### PR TITLE
[bug] #41 댓글 추천순일 때 좋아요 UI가 순서가 반대인 오류

### DIFF
--- a/src/app/(route)/store/[id]/page.tsx
+++ b/src/app/(route)/store/[id]/page.tsx
@@ -85,7 +85,7 @@ export default function RegisteredStore() {
         address={storeInfo?.address}
         category={storeInfo?.category}
       />
-      <div className="flex flex-col space-y-3 mt-3">
+      <div className="flex flex-col space-y-3 my-3">
         <RegisteredStoreImage
           images={storeInfo?.images}
           onImageClick={openImageModal}

--- a/src/app/_components/store/StoreReview.tsx
+++ b/src/app/_components/store/StoreReview.tsx
@@ -33,24 +33,24 @@ export const StoreReview = ({ storeId }: StoreReviewProps) => {
     setFilter(sortType);
   };
 
-  const fetchStoreInfo = useCallback(async () => {
-    try {
-      const storeInfo = await getStoreInfo(storeId, filter);
-      if (storeInfo) {
-        console.log(storeInfo);
-        setReviews(storeInfo.reviews || []);
-        setZeroDrinks(storeInfo.zeroDrinks || [[], [], []]);
-      }
-    } catch (error) {
-      console.error('판매점 리뷰 조회 오류', error);
-    }
-  }, [storeId, filter]);
-
   useEffect(() => {
+    const fetchStoreInfo = async () => {
+      try {
+        const storeInfo = await getStoreInfo(storeId, filter);
+        if (storeInfo) {
+          console.log(storeInfo);
+          setReviews(storeInfo.reviews || []);
+          setZeroDrinks(storeInfo.zeroDrinks || [[], [], []]);
+        }
+      } catch (error) {
+        console.error('판매점 리뷰 조회 오류', error);
+      }
+    };
+
     if (storeId) {
       fetchStoreInfo();
     }
-  }, [storeId, filter, fetchStoreInfo]);
+  }, [storeId, filter]);
 
   return (
     <div className="w-10/12 bg-white py-4 px-5 rounded-2xl ml-10 h-96 overflow-scroll mb-7">
@@ -64,7 +64,7 @@ export const StoreReview = ({ storeId }: StoreReviewProps) => {
         </div>
       </div>
 
-      <div className="flex flex-row justify-center space-x-10">
+      <div className="flex flex-row justify-center space-x-7">
         {[...Array(maxRank)].map((_, i) => (
           <div className="flex flex-row space-x-3" key={i}>
             {zeroDrinks[i] ? (

--- a/src/app/_components/store/UserReivew.tsx
+++ b/src/app/_components/store/UserReivew.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { LikeButton, LikedButton } from '@/app/assets';
 import { patchReviewLike } from '@/app/api/detail';
@@ -37,6 +37,11 @@ export const UserReview = ({
   const [likeCount, setLikeCount] = useState(initialLikeCount);
   const [loading, setLoading] = useState(false);
 
+  useEffect(() => {
+    setIsLiked(initialLiked);
+    setLikeCount(initialLikeCount);
+  }, [initialLiked, initialLikeCount]);
+
   const handleLikeClick = async () => {
     if (loading) return;
 
@@ -44,12 +49,8 @@ export const UserReview = ({
       setLoading(true);
       await patchReviewLike(review.id);
 
-      if (isLiked) {
-        setLikeCount((prev) => prev - 1);
-      } else {
-        setLikeCount((prev) => prev + 1);
-      }
       setIsLiked((prev) => !prev);
+      setLikeCount((prev) => prev + (isLiked ? -1 : 1));
     } catch (error) {
       console.error('좋아요 처리 실패:', error);
     } finally {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
판매점 상세페이지에서 댓글을 추천순으로 재정렬했을 때 보이는 좋아요 UI 순서가 반대로 보이는 오류가 발생했습니다.
- useState를 사용해서 좋아요 상태를 관리하고 있는데, `최신순`과 `추천순`의 api 호출은 잘 들어가지만, 그렇게 값이 바뀔때마다 즉시 상태가 동기화되지 않기 때문에 해당 오류가 발생하였습니다. 
- 이를 해결하기 위해 useEffect의 의존성 배열로 좋아요 상태를 추가하여 바뀔 시 즉시 동기화되도록 수정하였습니다.
<br>

## 2. 관련 스크린샷을 첨부해주세요.
<img width="300px" src="https://github.com/user-attachments/assets/e60b4afc-77fb-4e6b-883b-0b42ee1ff785">

<br>

## 3. 완료 사항
- [x] 좋아요 UI 순서가 반대로 보이는 오류 수정
close #81 
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 스토어 페이지의 레이아웃 마진이 상단 여백에서 수직 여백으로 변경되어, 보다 균형 잡힌 디자인을 제공합니다.
  - 음료 아이콘 간 간격이 조정되어 인터페이스 일관성이 향상되었습니다.
  
- **리팩토링**
  - 스토어 리뷰의 데이터 로딩 방식이 간소화되어 반응성이 개선되었습니다.
  - 사용자 리뷰의 좋아요 상태 및 수 업데이트 로직이 단순화되어 최신 상태를 신속하게 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->